### PR TITLE
extended logs + loader fix

### DIFF
--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGenerator.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGenerator.kt
@@ -1,15 +1,14 @@
 package com.asyncapi.plugin.core
 
+import com.asyncapi.plugin.core.generator.GenerationStrategy
+import com.asyncapi.plugin.core.generator.exception.AsyncAPISchemaGenerationException
 import com.asyncapi.plugin.core.generator.settings.GenerationRules
 import com.asyncapi.plugin.core.generator.settings.GenerationSettings
 import com.asyncapi.plugin.core.generator.settings.GenerationSources
-import com.asyncapi.plugin.core.generator.GenerationStrategy
-import com.asyncapi.plugin.core.generator.exception.AsyncAPISchemaGenerationException
 import com.asyncapi.plugin.core.generator.settings.SchemaFileSettings
 import com.asyncapi.plugin.core.generator.strategy.JsonGenerationStrategy
 import com.asyncapi.plugin.core.generator.strategy.YamlGenerationStrategy
 import com.asyncapi.plugin.core.logging.Logger
-import kotlin.jvm.Throws
 
 /**
  * AsyncAPI schema generator.
@@ -69,10 +68,12 @@ abstract class AsyncAPISchemaGenerator(
 
     @Throws(IllegalArgumentException::class)
     private fun checkRequiredParameters() {
+        resolveLogger().info("required parameters: checking...")
         if (classNames.isEmpty() && packageNames.isEmpty()) {
+            resolveLogger().error("required parameters: classNames or packageNames are required")
             throw IllegalArgumentException("classNames or packageNames are required")
         }
-
+        resolveLogger().info("required parameters: ok")
     }
 
     @Throws(IllegalArgumentException::class)
@@ -88,10 +89,20 @@ abstract class AsyncAPISchemaGenerator(
                 schemaFileSettings
         )
 
+        resolveLogger().info("generation strategy: checking...")
         return when(schemaFileFormat.toLowerCase()) {
-            "json" -> JsonGenerationStrategy(generationSettings)
-            "yaml" -> YamlGenerationStrategy(generationSettings)
-            else -> throw IllegalArgumentException("schemaFileFormat=$schemaFileFormat not recognized")
+            "json" -> {
+                resolveLogger().info("generation strategy: json")
+                JsonGenerationStrategy(generationSettings)
+            }
+            "yaml" -> {
+                resolveLogger().info("generation strategy: yaml")
+                YamlGenerationStrategy(generationSettings)
+            }
+            else -> {
+                resolveLogger().error("generation strategy: $schemaFileFormat not recognized")
+                throw IllegalArgumentException("schemaFileFormat=$schemaFileFormat not recognized")
+            }
         }
     }
 

--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/generator/strategy/JsonGenerationStrategy.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/generator/strategy/JsonGenerationStrategy.kt
@@ -1,13 +1,12 @@
 package com.asyncapi.plugin.core.generator.strategy
 
-import com.asyncapi.plugin.core.io.AsyncAPISchemaLoader
-import com.asyncapi.plugin.core.generator.settings.GenerationSettings
 import com.asyncapi.plugin.core.generator.GenerationStrategy
 import com.asyncapi.plugin.core.generator.exception.AsyncAPISchemaGenerationException
+import com.asyncapi.plugin.core.generator.settings.GenerationSettings
+import com.asyncapi.plugin.core.io.AsyncAPISchemaLoader
 import com.asyncapi.plugin.core.io.FileSystem
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlin.jvm.Throws
 
 /**
  * AsyncAPI schema generation strategy in json format.
@@ -44,6 +43,7 @@ class JsonGenerationStrategy(
         val schemaFileName = "${schemaClass.simpleName}-${generationSettings.schemaFile.namePostfix}.json"
         val schemaFilePath = generationSettings.schemaFile.path
 
+        generationSettings.logger.info("saving ${schemaClass.name} to $schemaFilePath")
         FileSystem.save(schemaFileName, schema, schemaFilePath)
     }
 

--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/generator/strategy/YamlGenerationStrategy.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/generator/strategy/YamlGenerationStrategy.kt
@@ -1,15 +1,14 @@
 package com.asyncapi.plugin.core.generator.strategy
 
-import com.asyncapi.plugin.core.generator.settings.GenerationSettings
 import com.asyncapi.plugin.core.generator.GenerationStrategy
 import com.asyncapi.plugin.core.generator.exception.AsyncAPISchemaGenerationException
+import com.asyncapi.plugin.core.generator.settings.GenerationSettings
 import com.asyncapi.plugin.core.io.AsyncAPISchemaLoader
 import com.asyncapi.plugin.core.io.FileSystem
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
-import kotlin.jvm.Throws
 
 /**
  * AsyncAPI schema generation strategy in yaml format.
@@ -46,6 +45,7 @@ class YamlGenerationStrategy(
         val schemaFileName = "${schemaClass.simpleName}-${generationSettings.schemaFile.namePostfix}.yaml"
         val schemaFilePath = generationSettings.schemaFile.path
 
+        generationSettings.logger.info("saving ${schemaClass.name} to $schemaFilePath")
         FileSystem.save(schemaFileName, schema, schemaFilePath)
     }
 

--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoader.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoader.kt
@@ -8,6 +8,7 @@ import com.asyncapi.v2.model.AsyncAPI
 import org.reflections.Reflections
 import org.reflections.scanners.SubTypesScanner
 import org.reflections.util.ConfigurationBuilder
+import org.reflections.util.FilterBuilder
 import java.net.URLClassLoader
 
 /**
@@ -93,6 +94,7 @@ open class AsyncAPISchemaLoader(
             try {
                 val reflections = Reflections(ConfigurationBuilder()
                         .forPackages(packageName)
+                        .filterInputsBy(FilterBuilder().includePackage(packageName))
                         .addScanners(SubTypesScanner(false))
                         .addUrls((sources.classLoader as URLClassLoader).urLs.asList())
                         .addClassLoader(sources.classLoader)

--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoader.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoader.kt
@@ -9,7 +9,6 @@ import org.reflections.Reflections
 import org.reflections.scanners.SubTypesScanner
 import org.reflections.util.ConfigurationBuilder
 import java.net.URLClassLoader
-import kotlin.jvm.Throws
 
 /**
  * Loads classes which extends [com.asyncapi.v2.model.AsyncAPI].
@@ -33,6 +32,7 @@ open class AsyncAPISchemaLoader(
      */
     @Throws(AsyncAPISchemaGenerationException::class)
     open fun load(): Set<Class<*>> {
+        logger.info("schemas loader: looking for schemas")
         val loadedClasses = loadClasses()
         val loadedClassesFromPackages = loadedClassesFromPackages()
 
@@ -44,27 +44,30 @@ open class AsyncAPISchemaLoader(
         val classesToLoad = sources.classes
         val loadedClasses = mutableSetOf<Class<*>>()
 
-        logger.info("Searching for schemas...")
+        logger.info("[classes]: loading...")
 
         if (classesToLoad.isEmpty()) {
-            logger.info("Given classes are empty. No classes found to load.")
+            logger.info("[classes]: nothing to load")
 
             return mutableSetOf()
         }
 
-        logger.info("Loading ${classesToLoad.size} given classes.")
+        logger.info("[classes]: loading ${classesToLoad.size} classes")
 
         classesToLoad.forEach { className ->
-            logger.info("Loading: $className")
+            logger.info("[classes]: loading $className")
             try {
                 loadedClasses.add(sources.classLoader.loadClass(className))
             } catch (classNotFoundException: ClassNotFoundException) {
+                logger.error("[classes]: can't load $className - ${classNotFoundException.message}")
                 throw AsyncAPISchemaGenerationException("Can't load class: $className", classNotFoundException)
             }
         }
 
         if (loadedClasses.isEmpty()) {
-            logger.info("No classes found to load.")
+            logger.info("[classes]: no classes loaded")
+        } else {
+            logger.info("[classes]: loaded ${loadedClasses.size} classes")
         }
 
         return loadedClasses
@@ -75,18 +78,18 @@ open class AsyncAPISchemaLoader(
         val packagesToScan = sources.packages
         val loadedClassesFromPackages = mutableSetOf<Class<*>>()
 
-        logger.info("Searching for schemas...")
+        logger.info("[packages]: searching...")
 
         if (packagesToScan.isEmpty()) {
-            logger.info("Given packages to scan are empty. No classes found to load.")
+            logger.info("[packages]: no classes found to load")
 
             return mutableSetOf()
         }
 
-        logger.info("Scanning ${packagesToScan.size} packages.")
+        logger.info("[packages]: scanning ${packagesToScan.size} packages")
 
         packagesToScan.forEach { packageName ->
-            logger.info("Scanning package: $packageName")
+            logger.info("[packages]: scanning $packageName")
             try {
                 val reflections = Reflections(ConfigurationBuilder()
                         .forPackages(packageName)
@@ -96,16 +99,20 @@ open class AsyncAPISchemaLoader(
                 )
 
                 val foundClasses = reflections.getSubTypesOf(AsyncAPI::class.java)
-                logger.info("Found: ${foundClasses.size} classes in $packageName")
+                logger.info("[packages]: found ${foundClasses.size} classes in $packageName")
+                foundClasses.map { it.name }.toList().forEach { logger.info(it) }
 
                 loadedClassesFromPackages.addAll(foundClasses)
             } catch (exception: Exception) {
+                logger.error("[classes]: can't load classes from $packageName - ${exception.message}")
                 throw AsyncAPISchemaGenerationException("Can't load classes from: $packageName", exception)
             }
         }
 
         if (loadedClassesFromPackages.isEmpty()) {
-            logger.info("No classes found to load.")
+            logger.info("[packages]: no classes loaded")
+        } else {
+            logger.info("[packages]: loaded ${loadedClassesFromPackages.size} classes")
         }
 
         return loadedClassesFromPackages

--- a/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/logging/Logger.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/main/kotlin/com/asyncapi/plugin/core/logging/Logger.kt
@@ -4,4 +4,6 @@ interface Logger {
 
     fun info(message: String)
 
+    fun error(message: String)
+
 }

--- a/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGeneratorImpl.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/AsyncAPISchemaGeneratorImpl.kt
@@ -21,6 +21,9 @@ class AsyncAPISchemaGeneratorImpl(
             override fun info(message: String) {
                 println(message)
             }
+            override fun error(message: String) {
+                println(message)
+            }
         }
     }
 

--- a/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/generator/strategy/GenerationStrategyTest.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/generator/strategy/GenerationStrategyTest.kt
@@ -16,6 +16,10 @@ open class GenerationStrategyTest {
         override fun info(message: String) {
             println(message)
         }
+
+        override fun error(message: String) {
+            println(message)
+        }
     }
 
     @BeforeEach

--- a/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoaderTest.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoaderTest.kt
@@ -1,5 +1,6 @@
 package com.asyncapi.plugin.core.io
 
+import com.asyncapi.plugin.core.generator.exception.AsyncAPISchemaGenerationException
 import com.asyncapi.plugin.core.generator.settings.GenerationSources
 import com.asyncapi.plugin.core.logging.Logger
 import org.junit.jupiter.api.Assertions
@@ -90,6 +91,63 @@ class AsyncAPISchemaLoaderTest {
 
         Assertions.assertTrue(expectedSchemas.asList().containsAll(loadedSchemas.stream().map { it.name }.toList()), "Loader must load all given classes from given packages")
 
+    }
+
+    @Test
+    fun `when class doesn't exists`() {
+        val classesToLoad = arrayOf(
+                "com.asyncapi.schemas.streetlights.GothamStreetlights"
+        )
+
+        val loader = AsyncAPISchemaLoader(mockLogger(), GenerationSources(classesToLoad, emptyArray(), composeClassLoader()))
+        Assertions.assertThrows(AsyncAPISchemaGenerationException::class.java) {loader.load()}
+    }
+
+    @Test
+    fun `when one of classes doesn't exists`() {
+        val classesToLoad = arrayOf(
+                "com.asyncapi.schemas.lamps.Lamps",
+                "com.asyncapi.schemas.streetlights.Streetlights",
+                "com.asyncapi.schemas.streetlights.GothamStreetlights"
+        )
+
+        val loader = AsyncAPISchemaLoader(mockLogger(), GenerationSources(classesToLoad, emptyArray(), composeClassLoader()))
+        Assertions.assertThrows(AsyncAPISchemaGenerationException::class.java) {loader.load()}
+    }
+
+    @Test
+    fun `when root package given`() {
+        val packagesToLoad = arrayOf(
+                "com.asyncapi.schemas"
+        )
+        val expectedSchemas = arrayOf(
+                "com.asyncapi.schemas.lamps.Lamps",
+                "com.asyncapi.schemas.streetlights.Streetlights"
+        )
+
+        val loader = AsyncAPISchemaLoader(mockLogger(), GenerationSources(emptyArray(), packagesToLoad, composeClassLoader()))
+        val loadedSchemas = loader.load()
+
+        Assertions.assertEquals(expectedSchemas.size, loadedSchemas.size, "Loader must load all given classes from given packages")
+
+        Assertions.assertTrue(expectedSchemas.asList().containsAll(loadedSchemas.stream().map { it.name }.toList()), "Loader must load all given classes from given packages")
+    }
+
+    @Test
+    fun `when single package given`() {
+        val packagesToLoad = arrayOf(
+                "com.asyncapi.schemas.lamps.Lamps"
+        )
+        val expectedSchemas = arrayOf(
+                "com.asyncapi.schemas.lamps.Lamps"
+        )
+
+        val loader = AsyncAPISchemaLoader(mockLogger(), GenerationSources(emptyArray(), packagesToLoad, composeClassLoader()))
+        val loadedSchemas = loader.load()
+
+        Assertions.assertEquals(expectedSchemas.size, loadedSchemas.size, "Loader must load all given classes from given packages")
+
+        Assertions.assertTrue(expectedSchemas.asList().containsAll(loadedSchemas.stream().map { it.name }.toList()), "Loader must load all given classes from given packages")
     }
 
 }

--- a/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoaderTest.kt
+++ b/asyncapi-plugin/asyncapi-plugin-core/src/test/kotlin/com/asyncapi/plugin/core/io/AsyncAPISchemaLoaderTest.kt
@@ -14,6 +14,11 @@ class AsyncAPISchemaLoaderTest {
             override fun info(message: String) {
                 println(message)
             }
+
+            override fun error(message: String) {
+                println(message)
+            }
+
         }
     }
 

--- a/asyncapi-plugin/asyncapi-plugin-gradle/src/main/kotlin/com/asyncapi/plugin/gradle/tasks/ResolveTask.kt
+++ b/asyncapi-plugin/asyncapi-plugin-gradle/src/main/kotlin/com/asyncapi/plugin/gradle/tasks/ResolveTask.kt
@@ -48,6 +48,10 @@ open class ResolveTask: DefaultTask() {
                         logger.info(message)
                     }
 
+                    override fun error(message: String) {
+                        logger.error(message)
+                    }
+
                 }
             }
 

--- a/asyncapi-plugin/asyncapi-plugin-maven/src/main/kotlin/com/asyncapi/plugin/maven/SchemaGeneratorMojo.kt
+++ b/asyncapi-plugin/asyncapi-plugin-maven/src/main/kotlin/com/asyncapi/plugin/maven/SchemaGeneratorMojo.kt
@@ -50,7 +50,12 @@ class SchemaGeneratorMojo: AbstractMojo() {
                         log.info(message)
                     }
 
+                    override fun error(message: String) {
+                        println(message)
+                    }
+
                 }
+
             }
 
             override fun resolveClassLoader(): ClassLoader {


### PR DESCRIPTION
* extended logs
* Loader loads schemas from given packages correctly. Previously it was loading all sub classes of AsyncAPI